### PR TITLE
Support zsh, removing dependency on $BASH_SOURCE

### DIFF
--- a/share/chgo/chgo.sh
+++ b/share/chgo/chgo.sh
@@ -1,5 +1,4 @@
-CHGO_SH=$(ps -o command -p $$ | grep -q bash && echo $BASH_SOURCE[@] || echo $0)
-CHGO_ROOT=$(cd "$(dirname $CHGO_SH)"/../.. && pwd)
+CHGO_ROOT=$(cd "$(dirname ${BASH_SOURCE:-$_})"/../.. && pwd)
 CHGO_VERSION="0.3.7"
 GOES=()
 

--- a/share/chgo/chgo.sh
+++ b/share/chgo/chgo.sh
@@ -1,4 +1,5 @@
-CHGO_ROOT=$(cd "$(dirname $BASH_SOURCE[@])"/../.. && pwd)
+CHGO_SH=$(ps -o command -p $$ | grep -q bash && echo $BASH_SOURCE[@] || echo $0)
+CHGO_ROOT=$(cd "$(dirname $CHGO_SH)"/../.. && pwd)
 CHGO_VERSION="0.3.7"
 GOES=()
 


### PR DESCRIPTION
In zsh, `$0` is equivalent to `$BASH_SOURCE[@]`.
