### PR TITLE
Support installation of Go 1.2.2+

### DIFF
--- a/share/chgo/chgo.sh
+++ b/share/chgo/chgo.sh
@@ -32,7 +32,7 @@ function chgo_install()
   else                                  arch="386"
   fi
 
-  # Default settings for new download location (1.3+)
+  # Default settings for new download location (1.2.2+)
   protocol="https"
   domain="storage.googleapis.com"
   path="golang"
@@ -46,7 +46,6 @@ function chgo_install()
 
   # Use older download location for versions <= 1.2.1
   if [[ $versioncomparator = 0 ]] || [[ $versioncomparator = 2 ]]; then
-    protocol="https"
     domain="go.googlecode.com"
     path="files"
   fi

--- a/share/chgo/chgo.sh
+++ b/share/chgo/chgo.sh
@@ -116,3 +116,38 @@ function chgo()
       ;;
   esac
 }
+
+# Version comparison shamelessly stolen from Dennis Williamson
+# http://stackoverflow.com/users/26428/dennis-williamson
+# http://stackoverflow.com/a/4025065/339727
+function vercomp ()
+{
+    if [[ $1 == $2 ]]
+    then
+        return 0
+    fi
+    local IFS=.
+    local i ver1=($1) ver2=($2)
+    # fill empty fields in ver1 with zeros
+    for ((i=${#ver1[@]}; i<${#ver2[@]}; i++))
+    do
+        ver1[i]=0
+    done
+    for ((i=0; i<${#ver1[@]}; i++))
+    do
+        if [[ -z ${ver2[i]} ]]
+        then
+            # fill empty fields in ver2 with zeros
+            ver2[i]=0
+        fi
+        if ((10#${ver1[i]} > 10#${ver2[i]}))
+        then
+            return 1
+        fi
+        if ((10#${ver1[i]} < 10#${ver2[i]}))
+        then
+            return 2
+        fi
+    done
+    return 0
+}


### PR DESCRIPTION
This is along the same lines as #5 - updating the download locations for Go as they've been moved.

However, as `1.2.1` and earlier aren't available at the new location, and `1.2.2+` isn't available at the old location we need to switch based on the version. 
