### PR TITLE
Updated chgo.sh to work with zsh

### DIFF
--- a/share/chgo/chgo.sh
+++ b/share/chgo/chgo.sh
@@ -1,4 +1,5 @@
-CHGO_ROOT=$(cd "$(dirname $BASH_SOURCE[@])"/../.. && pwd)
+SCRIPT_SOURCE=`dirname "${BASH_SOURCE:-$0}"`
+CHGO_ROOT=$(cd "$SCRIPT_SOURCE"/../.. && pwd)
 CHGO_VERSION="0.3.7"
 GOES=()
 


### PR DESCRIPTION
Zsh has no `BASH_SOURCE`, therefore we can leverage the `$0` (number zero) to obtain the path of the script that is being run. With this we can obtain the directory hosting the file with `dirname`.
